### PR TITLE
Fixed cooldown animations for cyCircled

### DIFF
--- a/RingMenu.lua
+++ b/RingMenu.lua
@@ -128,6 +128,7 @@ function RingMenuFrame_ConfigureButtons()
         
         button:SetID(i)
         button:SetPoint("CENTER", RingMenuFrame, "CENTER", 0, 0)
+        button:SetFrameLevel(2)
         button.isRingMenu = true
         button.isBonus = true
         button.buttonType = "RING_MENU"


### PR DESCRIPTION
Cooldown animations were not visible when using cyCircled, as they were actually underneath the icons.
Did not see any difference without cyCircled...