### PR TITLE
Allow to change frame level

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -10,6 +10,7 @@ local RingMenu_ringConfigDefault = {
     name = nil,
     keyBind = nil,
     closeOnClick = true,
+    level = 1,
     radius = 100,
     angle = 0,
     firstSlot = 13,
@@ -106,6 +107,7 @@ function RingMenu_UpdateRing(ringID)
     local rf = RingMenu.ringFrame[ringID]
     
     local frameSize = 2 * config.radius * config.backdropScale
+    rf:SetFrameLevel(config.level)
     rf:SetSize(frameSize, frameSize)
     rf.backdrop:SetVertexColor(config.backdropColor.r, config.backdropColor.g, config.backdropColor.b, config.backdropColor.a)
     rf.toggleButton:SetAttribute("allowMultipleOpenRings", RingMenu_globalConfig.allowMultipleOpenRings)

--- a/options.lua
+++ b/options.lua
@@ -105,6 +105,12 @@ RingMenu.ringConfigWidgets = {
         widgetType = "checkbox",
     },
     {
+        name = "level",
+        label = "Level",
+        widgetType = "slider",
+        min = 1, max = 100, valueStep = 1,
+    },
+    {
         name = "backdropColor",
         label = "Backdrop Color",
         widgetType = "color",


### PR DESCRIPTION
Hello, frame level is 1 by default, which means that the frame has the same level as its parent frame. But in my case ring menus were behind frames of some addons (Shadowed Unit Frames, for example). 
Now I have added ability to set frame level higher than default and make a ring menu overlap all other frames.
![image](https://user-images.githubusercontent.com/244044/100452780-dd582300-30ca-11eb-8ee9-df8c953f3650.png)
